### PR TITLE
Fixed the git repo URL in install instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ container-agent is a small python agent designed to manage a [group](#container-
 
 ```
 virtualenv env
-env/bin/pip install git+http://github.com/GoogleCloudPlatform/container-vm-agent.git
+env/bin/pip install git+http://github.com/GoogleCloudPlatform/container-agent.git
 env/bin/container-agent <path/to/manifest.yaml>
 ```
 


### PR DESCRIPTION
Hi,

It seems that at some point, the URL for the github repo was changed,
but the URL in the README's installation instructions wasn't.

Thanks,
