### PR TITLE
Fix entry point for bin script

### DIFF
--- a/container_agent/run_containers.py
+++ b/container_agent/run_containers.py
@@ -435,7 +435,6 @@ def RunContainers(containers):
         proc = subprocess.Popen(
             [DOCKER_CMD, 'run', '-d'] +
             ['--name', ctr.name] +
-            FlagOrNothing(ctr.hostname, '--hostname') +
             FlagOrNothing(ctr.working_dir, '--workdir') +
             FlagOrNothing(ctr.network_from, '--net') +
             FlagList(['%s:%s%s' % (p[0], p[1], p[2])

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
   packages = ['container_agent'],
   entry_points = {
     'console_scripts': [
-      'container-agent = container_agent.run_containers:run'
+      'container-agent = container_agent.run_containers:main'
     ],
   },
 )


### PR DESCRIPTION
Did you guys mean main here? There's no run function in run_containers.

When I run env/bin/container-agent:
ImportError: <module 'container_agent.run_containers' from '/root/env/local/lib/python2.7/site-packages/container_agent/run_containers.pyc'> has no 'run' attribute

Let me know if I can help with anything else, I find the project really interesting :)
